### PR TITLE
feat(phase-2): episodic memory with pgvector + sentence-transformers

### DIFF
--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -30,7 +30,7 @@ async def get_db() -> AsyncSession:
 async def init_db() -> None:
     """Create all tables. Called on app startup."""
     # Import all models so Base knows about them before create_all
-    import models.user  # noqa: F401
+    import models.user  # noqa: F401  — registers User, Call, Memory with Base
 
     async with engine.begin() as conn:
         # Enable pgvector extension

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 from config import get_settings
 from db.database import init_db
-from routers import calls
+from routers import calls, memory
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -29,6 +29,11 @@ async def _prewarm_models():
     logger.info("Pre-warming Kokoro TTS pipeline…")
     await asyncio.to_thread(get_kokoro)
     logger.info("Kokoro ready.")
+
+    from services.memory_service import _get_embedder as get_embedder
+    logger.info("Pre-warming sentence-transformer embedding model…")
+    await asyncio.to_thread(get_embedder)
+    logger.info("Embedding model ready.")
 
 
 @asynccontextmanager
@@ -63,6 +68,7 @@ os.makedirs(audio_dir, exist_ok=True)
 app.mount("/audio", StaticFiles(directory=audio_dir), name="audio")
 
 app.include_router(calls.router, prefix="/calls", tags=["calls"])
+app.include_router(memory.router, prefix="/memory", tags=["memory"])
 
 
 @app.get("/health")

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -5,6 +5,7 @@ from typing import Optional
 from sqlalchemy import String, Text, Float, Boolean, ForeignKey, DateTime, Time, JSON
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.dialects.postgresql import UUID
+from pgvector.sqlalchemy import Vector
 
 from db.database import Base
 
@@ -45,5 +46,27 @@ class Call(Base):
     mood_delta: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     flagged: Mapped[bool] = mapped_column(Boolean, default=False)
+    # Memories injected into this call's system prompt (fetched once at call start)
+    retrieved_memories: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     user: Mapped["User"] = relationship("User", back_populates="calls")
+    memories: Mapped[list["Memory"]] = relationship("Memory", back_populates="source_call", foreign_keys="Memory.source_call_id")
+
+
+class Memory(Base):
+    __tablename__ = "memories"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    embedding: Mapped[Optional[list]] = mapped_column(Vector(384), nullable=True)
+    source_call_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("calls.id"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    source_call: Mapped[Optional["Call"]] = relationship("Call", back_populates="memories", foreign_keys=[source_call_id])

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -1,0 +1,39 @@
+"""
+Memory router — read-only endpoints for the family dashboard (Phase 4).
+"""
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import get_db
+from models.user import Memory
+
+router = APIRouter()
+
+
+@router.get("/{user_id}")
+async def get_memories(
+    user_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """Return all memories for a user, newest first."""
+    result = await db.execute(
+        select(Memory)
+        .where(Memory.user_id == user_id)
+        .order_by(Memory.created_at.desc())
+    )
+    memories = result.scalars().all()
+
+    return [
+        {
+            "id": str(m.id),
+            "content": m.content,
+            "source_call_id": str(m.source_call_id) if m.source_call_id else None,
+            "created_at": m.created_at.isoformat() if isinstance(m.created_at, datetime) else m.created_at,
+        }
+        for m in memories
+    ]

--- a/backend/services/call_manager.py
+++ b/backend/services/call_manager.py
@@ -21,6 +21,7 @@ from twilio.twiml.voice_response import VoiceResponse
 from config import get_settings
 from models.user import Call, User
 from services import llm as llm_service
+from services import memory_service
 from services import stt as stt_service
 from services import tts as tts_service
 
@@ -90,7 +91,14 @@ async def build_opening_greeting(
     Generate the opening greeting TTS audio and return TwiML that plays it
     then opens the first <Record> to capture the user's response.
     """
-    llm_resp = await llm_service.generate_opening(user.name)
+    from datetime import date
+
+    # Retrieve relevant memories and inject into system prompt
+    context = f"Today is {date.today().strftime('%A, %B %d %Y')}. Calling {user.name}."
+    memories = await memory_service.get_relevant_memories(user.id, context, db)
+    call.retrieved_memories = memories or None
+
+    llm_resp = await llm_service.generate_opening(user.name, memories=memories)
 
     # Persist first assistant turn
     messages = list(call.messages or [])
@@ -151,8 +159,9 @@ async def build_turn_response(
 
     call.turn_count = (call.turn_count or 0) + 1
 
-    # --- LLM ---
-    llm_resp = await llm_service.chat(messages, user_name=user.name)
+    # --- LLM — pass through memories that were fetched at call start ---
+    memories = call.retrieved_memories or ""
+    llm_resp = await llm_service.chat(messages, user_name=user.name, memories=memories)
     logger.info(f"Aria says: '{llm_resp.text}'  end={llm_resp.should_end}  escalate={llm_resp.should_escalate}")
 
     messages.append({"role": "assistant", "content": llm_resp.text})
@@ -210,7 +219,7 @@ async def build_turn_response(
 # ---------------------------------------------------------------------------
 
 async def finalise_call(call: Call, db: AsyncSession) -> None:
-    """Write ended_at and flatten the transcript from message history."""
+    """Write ended_at, flatten the transcript, then extract and store memories."""
     call.ended_at = datetime.utcnow()
 
     messages = call.messages or []
@@ -222,6 +231,15 @@ async def finalise_call(call: Call, db: AsyncSession) -> None:
 
     await db.commit()
     logger.info(f"Call finalised  id={call.id}  turns={call.turn_count}")
+
+    # Extract facts from the transcript and store as embeddings for future calls
+    if call.transcript:
+        await memory_service.extract_and_store_memories(
+            user_id=call.user_id,
+            call_id=call.id,
+            transcript=call.transcript,
+            db=db,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -54,6 +54,7 @@ Your personality:
 - Never mention that you are an AI unless directly asked.
 - Speak naturally. Use their name occasionally but not every turn.
 
+{memories_section}
 Today is {today}.
 
 If you want to end the call naturally, add the token {goodbye} at the very end of your response.
@@ -63,9 +64,20 @@ Do NOT include the tokens mid-sentence — always place them at the absolute end
 """
 
 
-def build_system_prompt(user_name: str) -> str:
+def build_system_prompt(user_name: str, memories: str = "") -> str:
+    if memories:
+        memories_section = (
+            f"What you remember about {user_name} from past conversations:\n"
+            f"{memories}\n\n"
+            "Reference these naturally when relevant — weave them into conversation, "
+            "don't list them all at once.\n"
+        )
+    else:
+        memories_section = ""
+
     return SYSTEM_PROMPT_TEMPLATE.format(
         user_name=user_name,
+        memories_section=memories_section,
         today=date.today().strftime("%A, %B %d %Y"),
         goodbye=GOODBYE_TOKEN,
         escalate=ESCALATE_TOKEN,
@@ -79,6 +91,7 @@ def build_system_prompt(user_name: str) -> str:
 async def chat(
     messages: list[dict],
     user_name: str,
+    memories: str = "",
     temperature: float = 0.7,
 ) -> LLMResponse:
     """
@@ -90,7 +103,7 @@ async def chat(
     payload = {
         "model": settings.ollama_model,
         "messages": [
-            {"role": "system", "content": build_system_prompt(user_name)},
+            {"role": "system", "content": build_system_prompt(user_name, memories=memories)},
             *messages,
         ],
         "stream": False,
@@ -134,7 +147,7 @@ def _parse_response(raw: str) -> LLMResponse:
 # Opening greeting helper
 # ---------------------------------------------------------------------------
 
-async def generate_opening(user_name: str) -> LLMResponse:
+async def generate_opening(user_name: str, memories: str = "") -> LLMResponse:
     """Generate the very first line of a call — warm, brief, specific."""
     messages = [
         {
@@ -145,4 +158,4 @@ async def generate_opening(user_name: str) -> LLMResponse:
             ),
         }
     ]
-    return await chat(messages, user_name=user_name)
+    return await chat(messages, user_name=user_name, memories=memories)

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -1,0 +1,202 @@
+"""
+Episodic memory service — Phase 2.
+
+Two public functions:
+
+  extract_and_store_memories(user_id, call_id, transcript, db)
+      Called after every call.  Prompts Ollama to extract key facts from the
+      transcript, embeds each fact with sentence-transformers, and stores them
+      in the memories table.
+
+  get_relevant_memories(user_id, context, db, top_k=5)
+      Called before every call.  Embeds the context string, runs a cosine
+      similarity search against the user's memories via pgvector, and returns
+      the top-k facts as a formatted bullet string ready for the system prompt.
+
+The sentence-transformer model is loaded lazily on first use and cached.
+Use _get_embedder() directly during startup pre-warm.
+"""
+
+import asyncio
+import logging
+import uuid
+from functools import lru_cache
+
+import httpx
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config import get_settings
+from models.user import Memory
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+EMBEDDING_DIM = 384
+
+
+# ---------------------------------------------------------------------------
+# Embedding model singleton
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=1)
+def _get_embedder():
+    from sentence_transformers import SentenceTransformer
+
+    logger.info(f"Loading sentence-transformer model ({EMBEDDING_MODEL})…")
+    model = SentenceTransformer(EMBEDDING_MODEL)
+    logger.info("Embedding model ready.")
+    return model
+
+
+def _embed(text_input: str) -> list[float]:
+    """Synchronous embedding — call via asyncio.to_thread."""
+    model = _get_embedder()
+    vec = model.encode(text_input, normalize_embeddings=True)
+    return vec.tolist()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+async def extract_and_store_memories(
+    user_id: uuid.UUID,
+    call_id: uuid.UUID,
+    transcript: str,
+    db: AsyncSession,
+) -> int:
+    """
+    Extract key facts from a call transcript and persist them as embeddings.
+    Returns the number of memories stored.
+    """
+    if not transcript.strip():
+        logger.info(f"Empty transcript for call={call_id}, skipping memory extraction.")
+        return 0
+
+    facts = await _extract_facts(transcript)
+    if not facts:
+        logger.info(f"No facts extracted from call={call_id}.")
+        return 0
+
+    count = 0
+    for fact in facts:
+        fact = fact.strip()
+        if not fact:
+            continue
+        embedding = await asyncio.to_thread(_embed, fact)
+        db.add(Memory(
+            user_id=user_id,
+            source_call_id=call_id,
+            content=fact,
+            embedding=embedding,
+        ))
+        count += 1
+
+    await db.commit()
+    logger.info(f"Stored {count} memories for user={user_id} from call={call_id}.")
+    return count
+
+
+async def get_relevant_memories(
+    user_id: uuid.UUID,
+    context: str,
+    db: AsyncSession,
+    top_k: int = 5,
+) -> str:
+    """
+    Retrieve the top-k most relevant memories for the given context string.
+    Returns a formatted bullet string, or empty string if no memories exist.
+    """
+    embedding = await asyncio.to_thread(_embed, context)
+    # pgvector expects the vector as a string literal: '[0.1, 0.2, ...]'
+    embedding_str = "[" + ",".join(f"{x:.8f}" for x in embedding) + "]"
+
+    # Use sqlalchemy text() — asyncpg handles the raw SQL fine.
+    # <=> is cosine distance in pgvector (lower = more similar).
+    result = await db.execute(
+        text("""
+            SELECT content
+            FROM memories
+            WHERE user_id = :user_id
+              AND embedding IS NOT NULL
+            ORDER BY embedding <=> CAST(:embedding AS vector)
+            LIMIT :top_k
+        """),
+        {
+            "user_id": str(user_id),
+            "embedding": embedding_str,
+            "top_k": top_k,
+        },
+    )
+    rows = result.fetchall()
+    if not rows:
+        return ""
+
+    formatted = "\n".join(f"- {row[0]}" for row in rows)
+    logger.info(f"Retrieved {len(rows)} memories for user={user_id}.")
+    return formatted
+
+
+# ---------------------------------------------------------------------------
+# Fact extraction via Ollama
+# ---------------------------------------------------------------------------
+
+_EXTRACTION_PROMPT = """\
+You are analyzing a phone call transcript to extract key facts about the user \
+(the person Aria is calling — not Aria herself).
+
+Extract a concise bullet list of facts. Include:
+- Names of family members or friends mentioned
+- Names of pets
+- Health mentions (symptoms, medications, appointments, pain)
+- Recent events or activities the user described
+- Hobbies, preferences, or personal interests
+- Any upcoming plans or events the user mentioned
+
+Rules:
+- One fact per line, starting with "- "
+- Be specific and concrete (e.g. "daughter's name is Sarah", not "has a daughter")
+- Maximum 10 facts
+- If nothing notable was mentioned, return an empty response — do not invent facts
+
+Transcript:
+{transcript}
+
+Facts:"""
+
+
+async def _extract_facts(transcript: str) -> list[str]:
+    """Ask Ollama to extract a bullet list of facts from a transcript."""
+    prompt = _EXTRACTION_PROMPT.format(transcript=transcript)
+
+    try:
+        async with httpx.AsyncClient(
+            base_url=settings.ollama_base_url, timeout=90.0
+        ) as client:
+            resp = await client.post(
+                "/api/generate",
+                json={
+                    "model": settings.ollama_model,
+                    "prompt": prompt,
+                    "stream": False,
+                    "options": {"temperature": 0.2},
+                },
+            )
+            resp.raise_for_status()
+            raw = resp.json().get("response", "").strip()
+    except Exception as exc:
+        logger.error(f"Fact extraction LLM call failed: {exc}")
+        return []
+
+    facts = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if line.startswith("- "):
+            facts.append(line[2:].strip())
+        elif line.startswith("• "):
+            facts.append(line[2:].strip())
+
+    logger.info(f"Extracted {len(facts)} facts: {facts}")
+    return facts


### PR DESCRIPTION
- Add Memory model (content, vector(384), source_call_id) to ORM + DB
- Add retrieved_memories column to Call (stores memories injected per call)
- memory_service.py:
    - _get_embedder(): lazy-loaded all-MiniLM-L6-v2 singleton
    - extract_and_store_memories(): prompts Ollama to extract facts from transcript, embeds each fact, stores in memories table
    - get_relevant_memories(): cosine similarity search via pgvector <=>
      returns top-k facts as formatted bullet string
- llm.py: build_system_prompt() + chat() + generate_opening() accept memories param; injects "What you remember about {name}" section
- call_manager.py:
    - build_opening_greeting() fetches relevant memories before LLM call
    - build_turn_response() passes stored memories on every turn
    - finalise_call() triggers extract_and_store_memories() after hangup
- routers/memory.py: GET /memory/{user_id} returns all memories newest-first
- main.py: pre-warms embedding model on startup alongside Whisper + Kokoro