### PR TITLE
feat(phase-3): passive mood signals from speech audio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build/
 # TTS audio output (generated at runtime)
 backend/audio/*.wav
 backend/audio/*.mp3
+backend/audio/recordings/
 
 # Pytest / coverage
 .pytest_cache/

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 from config import get_settings
 from db.database import init_db
-from routers import calls, memory
+from routers import calls, memory, mood
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -44,6 +44,7 @@ async def lifespan(app: FastAPI):
 
     audio_dir = settings.audio_dir
     os.makedirs(audio_dir, exist_ok=True)
+    os.makedirs(os.path.join(audio_dir, "recordings"), exist_ok=True)
     logger.info(f"Audio directory ready at {audio_dir}")
 
     await _prewarm_models()
@@ -69,6 +70,7 @@ app.mount("/audio", StaticFiles(directory=audio_dir), name="audio")
 
 app.include_router(calls.router, prefix="/calls", tags=["calls"])
 app.include_router(memory.router, prefix="/memory", tags=["memory"])
+app.include_router(mood.router, prefix="/mood", tags=["mood"])
 
 
 @app.get("/health")

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -3,6 +3,7 @@ from datetime import datetime, time
 from typing import Optional
 
 from sqlalchemy import String, Text, Float, Boolean, ForeignKey, DateTime, Time, JSON
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.dialects.postgresql import UUID
 from pgvector.sqlalchemy import Vector
@@ -44,6 +45,7 @@ class Call(Base):
     turn_count: Mapped[int] = mapped_column(default=0)
     mood_score: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     mood_delta: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    mood_features: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
     summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     flagged: Mapped[bool] = mapped_column(Boolean, default=False)
     # Memories injected into this call's system prompt (fetched once at call start)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ python-multipart==0.0.12
 aiofiles==24.1.0
 pgvector==0.3.5
 sentence-transformers==3.1.1
+librosa==0.10.2

--- a/backend/routers/calls.py
+++ b/backend/routers/calls.py
@@ -11,7 +11,7 @@ import logging
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Form, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Form, Request
 from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,6 +24,7 @@ from services.call_manager import (
     build_opening_greeting,
     build_turn_response,
     finalise_call,
+    post_call_processing,
 )
 
 router = APIRouter()
@@ -132,6 +133,7 @@ async def call_turn(
 @router.post("/status/{call_id}")
 async def call_status(
     call_id: uuid.UUID,
+    background_tasks: BackgroundTasks,
     CallSid: str = Form(...),
     CallStatus: str = Form(...),
     CallDuration: str = Form(default="0"),
@@ -143,5 +145,7 @@ async def call_status(
         call = await db.get(Call, call_id)
         if call and not call.ended_at:
             await finalise_call(call, db)
+            # Memory extraction + mood scoring run after we respond to Twilio
+            background_tasks.add_task(post_call_processing, call_id)
 
     return Response(status_code=204)

--- a/backend/routers/mood.py
+++ b/backend/routers/mood.py
@@ -1,0 +1,41 @@
+"""
+Mood router — data source for the family dashboard chart (Phase 4).
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.database import get_db
+from models.user import Call
+
+router = APIRouter()
+
+
+@router.get("/{user_id}")
+async def get_mood_history(
+    user_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Return all mood scores for a user ordered by date ascending.
+    Used by the dashboard to render the weekly mood trend chart.
+    """
+    result = await db.execute(
+        select(Call.id, Call.started_at, Call.mood_score, Call.flagged)
+        .where(Call.user_id == user_id, Call.mood_score.isnot(None))
+        .order_by(Call.started_at.asc())
+    )
+    rows = result.all()
+
+    return [
+        {
+            "call_id": str(r.id),
+            "started_at": r.started_at.isoformat() if r.started_at else None,
+            "mood_score": r.mood_score,
+            "flagged": r.flagged,
+        }
+        for r in rows
+    ]

--- a/backend/services/call_manager.py
+++ b/backend/services/call_manager.py
@@ -2,35 +2,38 @@
 Call manager — orchestrates the full call lifecycle.
 
 Responsibilities:
-  • Trigger an outbound Twilio call
-  • Build the opening-greeting TwiML (on call answer)
+  • Trigger an outbound Twilio call (pre-generates greeting before dialing)
+  • Build the opening-greeting TwiML (instant response on call answer)
   • Build each turn's TwiML (transcribe → LLM → TTS → Record loop)
-  • Finalise the call record in the database
-  • Trigger an SMS escalation when the LLM sets the ESCALATE flag
+  • Finalise the call record (fast — just writes ended_at + transcript)
+  • post_call_processing() — background task for memory extraction + mood scoring
 """
 
 import logging
+import os
 import uuid
 from datetime import datetime
 
-import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 from twilio.rest import Client
 from twilio.twiml.voice_response import VoiceResponse
 
 from config import get_settings
 from models.user import Call, User
+from services import escalation as escalation_service
 from services import llm as llm_service
 from services import memory_service
+from services import mood as mood_service
 from services import stt as stt_service
 from services import tts as tts_service
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
-MAX_TURNS = 12          # end call after this many exchanges
-SILENCE_TIMEOUT = 6    # seconds of silence before Twilio stops recording
-MAX_RECORD_SECONDS = 60 # max seconds per user turn
+MAX_TURNS = 12
+SILENCE_TIMEOUT = 6
+MAX_RECORD_SECONDS = 60
+MOOD_ALERT_THRESHOLD = 0.35   # flag if mood drops below this vs baseline
 
 
 # ---------------------------------------------------------------------------
@@ -41,12 +44,9 @@ async def trigger_outbound_call(user: User, db: AsyncSession) -> str:
     """
     Pre-generate the greeting (memories → LLM → TTS) BEFORE dialing so the
     webhook can respond instantly and never hit Twilio's 15-second timeout.
-
-    Returns the Twilio call SID.
     """
     from datetime import date
 
-    # 1. Create the call record first so we have an ID to reference
     call_record = Call(
         user_id=user.id,
         started_at=datetime.utcnow(),
@@ -57,23 +57,22 @@ async def trigger_outbound_call(user: User, db: AsyncSession) -> str:
     await db.commit()
     await db.refresh(call_record)
 
-    # 2. Fetch relevant memories
+    # Fetch relevant memories
     context = f"Today is {date.today().strftime('%A, %B %d %Y')}. Calling {user.name}."
     memories = await memory_service.get_relevant_memories(user.id, context, db)
     call_record.retrieved_memories = memories or None
-    logger.info(f"Memories retrieved for call={call_record.id}: {bool(memories)}")
 
-    # 3. Generate opening LLM response
+    # Generate opening LLM response
     llm_resp = await llm_service.generate_opening(user.name, memories=memories)
     call_record.messages = [{"role": "assistant", "content": llm_resp.text}]
 
-    # 4. Synthesise TTS audio — store filename so webhook plays it instantly
+    # Synthesise TTS audio
     filename = await tts_service.synthesise(llm_resp.text)
     call_record.greeting_audio = filename
     await db.commit()
     logger.info(f"Greeting pre-generated: {filename}")
 
-    # 5. Now dial — webhook will return TwiML in milliseconds
+    # Dial
     webhook_url = f"{settings.base_url.rstrip('/')}/calls/webhook/{user.id}"
     status_url = f"{settings.base_url.rstrip('/')}/calls/status/{call_record.id}"
 
@@ -101,14 +100,9 @@ async def trigger_outbound_call(user: User, db: AsyncSession) -> str:
 async def build_opening_greeting(
     user: User, call: Call, db: AsyncSession
 ) -> VoiceResponse:
-    """
-    Play the pre-generated greeting audio and open the first <Record>.
-    The greeting was generated in trigger_outbound_call() before dialing
-    so this webhook responds in milliseconds — well within Twilio's 15s limit.
-    """
+    """Play pre-generated greeting and open first <Record>. Responds in ms."""
     filename = call.greeting_audio
     if not filename:
-        # Fallback: generate on the fly (should only happen in edge cases)
         logger.warning(f"No pre-generated greeting for call={call.id}, generating now.")
         memories = call.retrieved_memories or ""
         llm_resp = await llm_service.generate_opening(user.name, memories=memories)
@@ -131,9 +125,7 @@ async def build_opening_greeting(
         play_beep=False,
         transcribe=False,
     )
-    # Fallback if <Record> gets no audio at all
     twiml.redirect(turn_url, method="POST")
-
     return twiml
 
 
@@ -147,68 +139,62 @@ async def build_turn_response(
     recording_url: str,
     db: AsyncSession,
 ) -> VoiceResponse:
-    """
-    1. Download & transcribe the user's recording.
-    2. Append user turn to conversation history.
-    3. Call Ollama for a response.
-    4. Synthesise response audio.
-    5. Return TwiML: <Play> + <Record> (or <Hangup> if conversation ends).
-    """
-    # --- Transcribe ---
     auth = None
     if settings.twilio_account_sid and settings.twilio_auth_token:
         auth = (settings.twilio_account_sid, settings.twilio_auth_token)
 
-    transcript = await stt_service.transcribe_url(recording_url, twilio_auth=auth)
-    logger.info(f"User said: '{transcript}'  (call={call.id})")
+    # Save recording for mood analysis later
+    turn_num = (call.turn_count or 0) + 1
+    recording_save_path = _recording_path(call.id, turn_num)
+
+    transcript = await stt_service.transcribe_url(
+        recording_url, twilio_auth=auth, save_path=recording_save_path
+    )
+    logger.info(f"User said: '{transcript}'  (call={call.id}  turn={turn_num})")
 
     messages = list(call.messages or [])
-
     if transcript:
         messages.append({"role": "user", "content": transcript})
 
-    call.turn_count = (call.turn_count or 0) + 1
+    call.turn_count = turn_num
 
-    # --- LLM — pass through memories that were fetched at call start ---
     memories = call.retrieved_memories or ""
     llm_resp = await llm_service.chat(messages, user_name=user.name, memories=memories)
-    logger.info(f"Aria says: '{llm_resp.text}'  end={llm_resp.should_end}  escalate={llm_resp.should_escalate}")
+    logger.info(f"Aria: '{llm_resp.text}'  end={llm_resp.should_end}  escalate={llm_resp.should_escalate}")
 
     messages.append({"role": "assistant", "content": llm_resp.text})
     call.messages = messages
 
-    # --- Persist ---
     if llm_resp.should_escalate:
         call.flagged = True
+        if user.family_phone:
+            escalation_service.send_sms(
+                user.family_phone, user.name,
+                "They mentioned something concerning during their call."
+            )
+
     await db.commit()
 
-    # --- TTS ---
     filename = await tts_service.synthesise(llm_resp.text)
     play_url = tts_service.audio_url(filename)
 
-    # --- Build TwiML ---
     twiml = VoiceResponse()
     twiml.play(play_url)
 
     should_hang_up = (
         llm_resp.should_end
         or call.turn_count >= MAX_TURNS
-        or not transcript  # user said nothing after a prompt
+        or not transcript
     )
 
     if should_hang_up:
         if not llm_resp.should_end:
-            # Max turns reached gracefully
             farewell = await tts_service.synthesise(
-                f"It was so lovely talking with you today, {user.name}. Take care, and I'll call again soon."
+                f"It was so lovely talking with you today, {user.name}. "
+                "Take care, and I'll call again soon."
             )
             twiml.play(tts_service.audio_url(farewell))
-
         twiml.hangup()
-
-        # Trigger SMS alert asynchronously (don't block the TwiML response)
-        if llm_resp.should_escalate and user.family_phone:
-            _send_escalation_sms(user)
     else:
         turn_url = _turn_url(user.id, call.id)
         twiml.record(
@@ -225,31 +211,110 @@ async def build_turn_response(
 
 
 # ---------------------------------------------------------------------------
-# Finalise call record
+# Finalise call (fast — called synchronously in status callback)
 # ---------------------------------------------------------------------------
 
 async def finalise_call(call: Call, db: AsyncSession) -> None:
-    """Write ended_at, flatten the transcript, then extract and store memories."""
+    """Write ended_at and flatten transcript. Heavy work runs in background."""
     call.ended_at = datetime.utcnow()
 
     messages = call.messages or []
-    lines = []
-    for msg in messages:
-        speaker = "Aria" if msg["role"] == "assistant" else "User"
-        lines.append(f"{speaker}: {msg['content']}")
+    lines = [
+        f"{'Aria' if m['role'] == 'assistant' else 'User'}: {m['content']}"
+        for m in messages
+    ]
     call.transcript = "\n".join(lines)
-
     await db.commit()
     logger.info(f"Call finalised  id={call.id}  turns={call.turn_count}")
 
-    # Extract facts from the transcript and store as embeddings for future calls
-    if call.transcript:
-        await memory_service.extract_and_store_memories(
-            user_id=call.user_id,
-            call_id=call.id,
-            transcript=call.transcript,
-            db=db,
-        )
+
+# ---------------------------------------------------------------------------
+# Post-call processing (background task — owns its own DB session)
+# ---------------------------------------------------------------------------
+
+async def post_call_processing(call_id: uuid.UUID) -> None:
+    """
+    Runs after a call ends as a FastAPI BackgroundTask.
+    Uses its own DB session — safe to run after the HTTP response is sent.
+
+    1. Memory extraction (LLM fact extraction + pgvector storage)
+    2. Mood scoring (librosa features + baseline comparison)
+    3. SMS escalation if mood drops significantly below baseline
+    """
+    from db.database import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as db:
+        call = await db.get(Call, call_id)
+        if not call:
+            logger.warning(f"post_call_processing: call {call_id} not found.")
+            return
+
+        user = await db.get(User, call.user_id)
+
+        # 1. Memory extraction
+        if call.transcript:
+            await memory_service.extract_and_store_memories(
+                call.user_id, call.id, call.transcript, db
+            )
+
+        # 2. Mood scoring
+        await _score_and_save_mood(call, user, db)
+
+
+async def _score_and_save_mood(call: Call, user: User | None, db: AsyncSession) -> None:
+    """Find per-turn recordings, extract features, compute score, persist."""
+    recordings_dir = os.path.join(settings.audio_dir, "recordings")
+    if not os.path.isdir(recordings_dir):
+        logger.info("No recordings directory — skipping mood scoring.")
+        return
+
+    # Collect all recordings saved for this call, in turn order
+    prefix = str(call.id)
+    recording_files = sorted([
+        os.path.join(recordings_dir, f)
+        for f in os.listdir(recordings_dir)
+        if f.startswith(prefix) and f.endswith(".wav")
+    ])
+
+    if not recording_files:
+        logger.info(f"No recordings found for call={call.id} — skipping mood.")
+        return
+
+    # Concatenate into one file
+    combined_path = os.path.join(recordings_dir, f"{call.id}_combined.wav")
+    ok = await mood_service.concatenate_recordings(recording_files, combined_path)
+    if not ok:
+        logger.warning(f"Could not concatenate recordings for call={call.id}.")
+        return
+
+    try:
+        features = await mood_service.extract_audio_features(combined_path)
+        baseline = await mood_service.get_user_baseline(call.user_id, db)
+        score = mood_service.compute_mood_score(features, baseline)
+
+        call.mood_features = features
+        call.mood_score = score
+        call.mood_delta = round(score - 0.5, 3) if baseline is None else round(score - 0.5, 3)
+
+        # Escalate on significant mood dip (only once we have a real baseline)
+        if baseline is not None and score < MOOD_ALERT_THRESHOLD:
+            call.flagged = True
+            if user and user.family_phone:
+                escalation_service.send_sms(
+                    user.family_phone,
+                    user.name if user else "the user",
+                    f"Their mood score today was {score:.2f}, notably lower than their recent baseline.",
+                )
+
+        await db.commit()
+        logger.info(f"Mood scored  call={call.id}  score={score}  baseline={'yes' if baseline else 'building'}")
+    finally:
+        # Clean up individual turn recordings; keep combined for audit if needed
+        for p in recording_files:
+            try:
+                os.remove(p)
+            except OSError:
+                pass
 
 
 # ---------------------------------------------------------------------------
@@ -260,19 +325,6 @@ def _turn_url(user_id: uuid.UUID, call_id: uuid.UUID) -> str:
     return f"{settings.base_url.rstrip('/')}/calls/turn/{user_id}/{call_id}"
 
 
-def _send_escalation_sms(user: User) -> None:
-    """Fire-and-forget SMS to family member via Twilio."""
-    try:
-        client = Client(settings.twilio_account_sid, settings.twilio_auth_token)
-        client.messages.create(
-            to=user.family_phone,
-            from_=settings.twilio_phone_number,
-            body=(
-                f"Aria alert: {user.name} may need a check-in. "
-                "They mentioned something during their daily call that warrants attention. "
-                "Please reach out to them soon."
-            ),
-        )
-        logger.info(f"Escalation SMS sent to {user.family_phone}")
-    except Exception as exc:
-        logger.error(f"SMS escalation failed: {exc}")
+def _recording_path(call_id: uuid.UUID, turn: int) -> str:
+    recordings_dir = os.path.join(settings.audio_dir, "recordings")
+    return os.path.join(recordings_dir, f"{call_id}_{turn:03d}.wav")

--- a/backend/services/call_manager.py
+++ b/backend/services/call_manager.py
@@ -14,6 +14,7 @@ import os
 import uuid
 from datetime import datetime
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from twilio.rest import Client
 from twilio.twiml.voice_response import VoiceResponse
@@ -57,13 +58,27 @@ async def trigger_outbound_call(user: User, db: AsyncSession) -> str:
     await db.commit()
     await db.refresh(call_record)
 
-    # Fetch relevant memories
-    context = f"Today is {date.today().strftime('%A, %B %d %Y')}. Calling {user.name}."
-    memories = await memory_service.get_relevant_memories(user.id, context, db)
+    # For the opening, use recent memories so Aria follows up on the last call.
+    # During the call, cosine search is used for contextual retrieval.
+    memories = await memory_service.get_recent_memories(user.id, db)
     call_record.retrieved_memories = memories or None
 
+    # Fetch previous call's opening so Aria doesn't repeat the same follow-up topic
+    prev_result = await db.execute(
+        select(Call)
+        .where(Call.user_id == user.id, Call.id != call_record.id, Call.messages.isnot(None))
+        .order_by(Call.started_at.desc())
+        .limit(1)
+    )
+    prev_call = prev_result.scalars().first()
+    prev_opening = None
+    if prev_call and prev_call.messages:
+        first_msg = prev_call.messages[0] if prev_call.messages else None
+        if first_msg and first_msg.get("role") == "assistant":
+            prev_opening = first_msg["content"]
+
     # Generate opening LLM response
-    llm_resp = await llm_service.generate_opening(user.name, memories=memories)
+    llm_resp = await llm_service.generate_opening(user.name, memories=memories, prev_opening=prev_opening)
     call_record.messages = [{"role": "assistant", "content": llm_resp.text}]
 
     # Synthesise TTS audio
@@ -152,6 +167,10 @@ async def build_turn_response(
     )
     logger.info(f"User said: '{transcript}'  (call={call.id}  turn={turn_num})")
 
+    # Detect user-initiated goodbye so Aria wraps up naturally
+    _goodbye_phrases = {"bye", "goodbye", "good bye", "talk later", "got to go", "gotta go", "take care", "have a good day"}
+    user_said_bye = any(phrase in transcript.lower() for phrase in _goodbye_phrases) if transcript else False
+
     messages = list(call.messages or [])
     if transcript:
         messages.append({"role": "user", "content": transcript})
@@ -181,10 +200,12 @@ async def build_turn_response(
     twiml = VoiceResponse()
     twiml.play(play_url)
 
+    # Don't end mid-conversation if Aria just asked a question
+    ends_with_question = llm_resp.text.rstrip().endswith("?")
     should_hang_up = (
-        llm_resp.should_end
+        (llm_resp.should_end and not ends_with_question)
+        or user_said_bye
         or call.turn_count >= MAX_TURNS
-        or not transcript
     )
 
     if should_hang_up:
@@ -278,6 +299,11 @@ async def _score_and_save_mood(call: Call, user: User | None, db: AsyncSession) 
 
     if not recording_files:
         logger.info(f"No recordings found for call={call.id} — skipping mood.")
+        return
+
+    MIN_TURNS_FOR_MOOD = 3
+    if (call.turn_count or 0) < MIN_TURNS_FOR_MOOD:
+        logger.info(f"Call too short ({call.turn_count} turns) — skipping mood scoring.")
         return
 
     # Concatenate into one file

--- a/backend/services/escalation.py
+++ b/backend/services/escalation.py
@@ -1,0 +1,41 @@
+"""
+SMS escalation service.
+
+Centralises all outbound SMS alerts so call_manager and mood scoring
+both use the same function.
+"""
+
+import logging
+
+from config import get_settings
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+
+def send_sms(to_number: str, user_name: str, reason: str) -> bool:
+    """
+    Send an SMS alert to a family member.
+    Returns True if the message was accepted by Twilio.
+    """
+    if not to_number:
+        logger.warning("SMS escalation skipped — no family phone number configured.")
+        return False
+    if not settings.twilio_account_sid or not settings.twilio_auth_token:
+        logger.warning("SMS escalation skipped — Twilio credentials not set.")
+        return False
+
+    try:
+        from twilio.rest import Client
+
+        client = Client(settings.twilio_account_sid, settings.twilio_auth_token)
+        client.messages.create(
+            to=to_number,
+            from_=settings.twilio_phone_number,
+            body=f"Aria alert for {user_name}: {reason} Please check in with them soon.",
+        )
+        logger.info(f"Escalation SMS sent to {to_number} — {reason}")
+        return True
+    except Exception as exc:
+        logger.error(f"SMS escalation failed: {exc}")
+        return False

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -28,7 +28,7 @@ settings = get_settings()
 GOODBYE_TOKEN = "[GOODBYE]"
 ESCALATE_TOKEN = "[ESCALATE]"
 
-_TOKEN_PATTERN = re.compile(r"\[(GOODBYE|ESCALATE)\]", re.IGNORECASE)
+_TOKEN_PATTERN = re.compile(r"\[?(GOODBYE|ESCALATE)\]?", re.IGNORECASE)
 
 
 @dataclass
@@ -50,6 +50,7 @@ Your personality:
 - Warm, unhurried, and genuinely curious.
 - Never interrupt. If there is silence, wait patiently.
 - If the user repeats something they already told you, respond with interest, not correction.
+- Never contradict or correct the user. If they say something that conflicts with your memory, gently go along with what they say now.
 - Keep responses very short — 1 to 3 sentences maximum. This is a phone call, not a text chat.
 - Never mention that you are an AI unless directly asked.
 - Speak naturally. Use their name occasionally but not every turn.
@@ -57,8 +58,8 @@ Your personality:
 {memories_section}
 Today is {today}.
 
-If you want to end the call naturally, add the token {goodbye} at the very end of your response.
-If the user mentions pain, an emergency, feeling very sad, or confusion about their location or identity: express care calmly, say you will have someone check on them shortly, and add the token {escalate} at the very end of your response.
+Only use {goodbye} when the conversation has reached a natural close and the user has said goodbye or indicated they need to go. Do NOT use {goodbye} if you have just asked a question or the conversation is still active.
+Only use {escalate} for genuine emergencies: the user mentions chest pain, a fall, a medical emergency, expresses they want to harm themselves, or is confused about where they are or who they are. Do NOT escalate for ordinary loneliness, missing family, feeling a bit down, or everyday sadness — those are normal and should be met with warmth and empathy, not alarm.
 
 Do NOT include the tokens mid-sentence — always place them at the absolute end, separated by a space.
 """
@@ -69,8 +70,9 @@ def build_system_prompt(user_name: str, memories: str = "") -> str:
         memories_section = (
             f"What you remember about {user_name} from past conversations:\n"
             f"{memories}\n\n"
-            "Reference these naturally when relevant — weave them into conversation, "
-            "don't list them all at once.\n"
+            "Use these as background context to personalise your responses — do NOT treat them as open questions to ask about. "
+            "Only bring up a memory if {user_name} raises the topic first, or if it's directly relevant to something they just said. "
+            "Never re-ask about something that has already been discussed and answered across calls.\n"
         )
     else:
         memories_section = ""
@@ -147,15 +149,26 @@ def _parse_response(raw: str) -> LLMResponse:
 # Opening greeting helper
 # ---------------------------------------------------------------------------
 
-async def generate_opening(user_name: str, memories: str = "") -> LLMResponse:
+async def generate_opening(user_name: str, memories: str = "", prev_opening: str = "") -> LLMResponse:
     """Generate the very first line of a call — warm, brief, specific."""
-    messages = [
-        {
-            "role": "user",
-            "content": (
-                f"Start the call now. Greet {user_name} warmly, mention that it's great to talk "
-                "with them today, and ask one gentle open-ended question about how they are feeling."
-            ),
-        }
-    ]
+    if memories:
+        avoid_clause = (
+            f" Do NOT ask about the same topic you opened with last time. "
+            f"Last call you started with: \"{prev_opening}\""
+            if prev_opening else ""
+        )
+        opening_instruction = (
+            f"Start the call now. Greet {user_name} warmly, then ask a specific follow-up "
+            f"question about something they mentioned in a recent conversation — like how an "
+            f"outing went, how they're feeling after an event, or how someone they mentioned is doing. "
+            f"Pick the most recent and meaningful thing from your memories. Keep it to 2 sentences max."
+            f"{avoid_clause}"
+        )
+    else:
+        opening_instruction = (
+            f"Start the call now. Greet {user_name} warmly and ask one gentle open-ended "
+            f"question about how they are feeling today."
+        )
+
+    messages = [{"role": "user", "content": opening_instruction}]
     return await chat(messages, user_name=user_name, memories=memories)

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -99,6 +99,35 @@ async def extract_and_store_memories(
     return count
 
 
+async def get_recent_memories(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+    top_k: int = 8,
+) -> str:
+    """
+    Retrieve the most recently stored memories for a user, ordered by creation
+    time. Used for opening greetings so Aria follows up on the last call's
+    topics rather than whatever scores highest in cosine similarity.
+    """
+    result = await db.execute(
+        text("""
+            SELECT content
+            FROM memories
+            WHERE user_id = :user_id
+            ORDER BY created_at DESC
+            LIMIT :top_k
+        """),
+        {"user_id": str(user_id), "top_k": top_k},
+    )
+    rows = result.fetchall()
+    if not rows:
+        return ""
+
+    formatted = "\n".join(f"- {row[0]}" for row in rows)
+    logger.info(f"Retrieved {len(rows)} recent memories for user={user_id}.")
+    return formatted
+
+
 async def get_relevant_memories(
     user_id: uuid.UUID,
     context: str,

--- a/backend/services/mood.py
+++ b/backend/services/mood.py
@@ -1,0 +1,203 @@
+"""
+Mood signals service — Phase 3.
+
+Extracts acoustic features from call audio using librosa and computes a
+mood score relative to the user's personal baseline.
+
+Librosa is imported lazily — it's slow to load and is not pre-warmed at
+startup. The first call with audio will take a few extra seconds.
+"""
+
+import asyncio
+import logging
+import os
+import uuid
+from typing import Optional
+
+import numpy as np
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Lazy librosa import
+# ---------------------------------------------------------------------------
+
+def _librosa():
+    import librosa  # noqa: PLC0415
+    return librosa
+
+
+# ---------------------------------------------------------------------------
+# Feature extraction
+# ---------------------------------------------------------------------------
+
+async def extract_audio_features(audio_path: str) -> dict:
+    """Extract acoustic features from a WAV file. Runs in a thread pool."""
+    return await asyncio.to_thread(_extract_sync, audio_path)
+
+
+def _extract_sync(audio_path: str) -> dict:
+    lib = _librosa()
+
+    try:
+        y, sr = lib.load(audio_path, sr=None, mono=True)
+    except Exception as exc:
+        logger.error(f"Could not load audio {audio_path}: {exc}")
+        return _empty_features()
+
+    if len(y) == 0 or sr == 0:
+        return _empty_features()
+
+    duration = len(y) / sr
+
+    # --- Energy ---
+    rms = lib.feature.rms(y=y)[0]
+    energy = float(np.mean(rms))
+
+    # --- Pitch (YIN) ---
+    try:
+        pitches = lib.yin(y, fmin=75, fmax=300)
+        voiced = pitches[(pitches > 75) & (pitches < 300)]
+        pitch_mean = float(np.mean(voiced)) if len(voiced) > 0 else 0.0
+        pitch_std = float(np.std(voiced)) if len(voiced) > 0 else 0.0
+    except Exception:
+        pitch_mean = 0.0
+        pitch_std = 0.0
+
+    # --- Speech rate (voiced frames per second) ---
+    voiced_frames = int(np.sum(rms > 0.01))
+    speech_rate = float(voiced_frames / duration) if duration > 0 else 0.0
+
+    # --- Pause ratio ---
+    total_frames = len(rms)
+    silent_frames = int(np.sum(rms < 0.01))
+    pause_ratio = float(silent_frames / total_frames) if total_frames > 0 else 0.5
+
+    features = {
+        "energy": round(energy, 6),
+        "pitch_mean": round(pitch_mean, 2),
+        "pitch_std": round(pitch_std, 2),
+        "speech_rate": round(speech_rate, 4),
+        "pause_ratio": round(pause_ratio, 4),
+        "duration_seconds": round(duration, 2),
+    }
+    logger.info(f"Extracted audio features: {features}")
+    return features
+
+
+def _empty_features() -> dict:
+    return {
+        "energy": 0.0,
+        "pitch_mean": 0.0,
+        "pitch_std": 0.0,
+        "speech_rate": 0.0,
+        "pause_ratio": 1.0,
+        "duration_seconds": 0.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mood scoring
+# ---------------------------------------------------------------------------
+
+def compute_mood_score(features: dict, baseline: Optional[dict]) -> float:
+    """
+    Score 0.0–1.0 relative to the user's personal baseline.
+      0.0 = much lower energy / engagement than baseline
+      0.5 = no baseline yet (neutral)
+      1.0 = much higher energy / engagement than baseline
+
+    Higher energy, higher pitch, faster speech rate → higher score.
+    Higher pause ratio → lower score.
+    """
+    if not baseline:
+        return 0.5
+
+    def delta_score(val: float, base: float, sensitivity: float = 1.5) -> float:
+        if base <= 0:
+            return 0.5
+        pct = (val - base) / base
+        return max(0.0, min(1.0, 0.5 + pct * sensitivity * 0.5))
+
+    energy_score  = delta_score(features.get("energy", 0),       baseline.get("energy", 0))
+    pitch_score   = delta_score(features.get("pitch_mean", 0),   baseline.get("pitch_mean", 1), sensitivity=1.0)
+    speech_score  = delta_score(features.get("speech_rate", 0),  baseline.get("speech_rate", 0))
+    # Higher pause ratio → worse mood → invert
+    pause_score   = 1.0 - delta_score(features.get("pause_ratio", 0.5), baseline.get("pause_ratio", 0.5))
+
+    score = (
+        energy_score * 0.35
+        + pitch_score  * 0.25
+        + speech_score * 0.25
+        + pause_score  * 0.15
+    )
+    return round(max(0.0, min(1.0, score)), 3)
+
+
+# ---------------------------------------------------------------------------
+# Baseline query
+# ---------------------------------------------------------------------------
+
+async def get_user_baseline(user_id: uuid.UUID, db: AsyncSession) -> Optional[dict]:
+    """
+    Average mood_features from the user's last 3 completed calls.
+    Returns None if fewer than 3 calls with features exist.
+    """
+    result = await db.execute(
+        text("""
+            SELECT mood_features
+            FROM calls
+            WHERE user_id  = :user_id
+              AND mood_features IS NOT NULL
+              AND ended_at  IS NOT NULL
+            ORDER BY ended_at DESC
+            LIMIT 3
+        """),
+        {"user_id": str(user_id)},
+    )
+    rows = result.fetchall()
+    if len(rows) < 3:
+        return None
+
+    keys = ["energy", "pitch_mean", "pitch_std", "speech_rate", "pause_ratio"]
+    baseline: dict = {}
+    for key in keys:
+        vals = [row[0][key] for row in rows if row[0] and key in row[0]]
+        baseline[key] = float(np.mean(vals)) if vals else 0.0
+    return baseline
+
+
+# ---------------------------------------------------------------------------
+# Audio helpers
+# ---------------------------------------------------------------------------
+
+async def concatenate_recordings(paths: list[str], output_path: str) -> bool:
+    """Concatenate per-turn WAV files into a single file for analysis."""
+    return await asyncio.to_thread(_concat_sync, paths, output_path)
+
+
+def _concat_sync(paths: list[str], output_path: str) -> bool:
+    import soundfile as sf
+
+    lib = _librosa()
+    chunks, sr_ref = [], None
+
+    for p in paths:
+        if not os.path.exists(p):
+            continue
+        try:
+            y, sr = lib.load(p, sr=None, mono=True)
+            if sr_ref is None:
+                sr_ref = sr
+            chunks.append(y)
+        except Exception as exc:
+            logger.warning(f"Skipping recording {p}: {exc}")
+
+    if not chunks or sr_ref is None:
+        return False
+
+    sf.write(output_path, np.concatenate(chunks), sr_ref, subtype="PCM_16")
+    return True

--- a/backend/services/stt.py
+++ b/backend/services/stt.py
@@ -33,19 +33,21 @@ def _get_model():
 # Public API
 # ---------------------------------------------------------------------------
 
-async def transcribe_url(recording_url: str, twilio_auth: tuple[str, str] | None = None) -> str:
+async def transcribe_url(
+    recording_url: str,
+    twilio_auth: tuple[str, str] | None = None,
+    save_path: str | None = None,
+) -> str:
     """
-    Download a Twilio recording URL (or any accessible audio URL) and
-    transcribe it with Whisper.  Returns the transcription string, or an
-    empty string if the audio could not be fetched / transcribed.
+    Download a Twilio recording URL and transcribe it with Whisper.
+    Returns the transcription string, or empty string on failure.
 
-    Twilio recording URLs require HTTP Basic Auth
-    (account_sid, auth_token) unless you've opened them publicly.
+    If `save_path` is provided, the raw audio bytes are also written to
+    that path for downstream processing (e.g. mood feature extraction).
     """
     if not recording_url:
         return ""
 
-    # Twilio appends no extension — request .wav explicitly for best compat
     url = recording_url if recording_url.endswith((".wav", ".mp3")) else recording_url + ".wav"
 
     logger.info(f"Downloading recording: {url}")
@@ -53,6 +55,12 @@ async def transcribe_url(recording_url: str, twilio_auth: tuple[str, str] | None
     if not audio_bytes:
         logger.warning("Recording download returned empty body.")
         return ""
+
+    if save_path:
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+        with open(save_path, "wb") as fh:
+            fh.write(audio_bytes)
+        logger.info(f"Recording saved to {save_path}")
 
     return await asyncio.to_thread(_transcribe_bytes, audio_bytes)
 

--- a/scripts/seed_mood_history.py
+++ b/scripts/seed_mood_history.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Seed 7 fake completed calls for Margaret with realistic mood scores.
+
+Day sequence:
+  Day -7  0.62  (baseline building)
+  Day -6  0.58  (baseline building)
+  Day -5  0.71  (baseline building — 3rd call, baseline now established)
+  Day -4  0.65  (normal)
+  Day -3  0.28  ← THE DIP — flagged, SMS triggered  ← demo moment
+  Day -2  0.55  (recovering)
+  Day -1  0.67  (back to normal)
+
+Usage (from repo root, venv active, DB running):
+  python scripts/seed_mood_history.py
+"""
+
+import asyncio
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+asyncpg://aria:aria@localhost:5433/aria_db",
+)
+
+# Mood sequence — (score, features_profile)
+# profiles: "normal", "good", "low"
+CALL_PLAN = [
+    # (days_ago, mood_score, profile, flagged)
+    (7, 0.62, "normal", False),
+    (6, 0.58, "normal", False),
+    (5, 0.71, "good",   False),
+    (4, 0.65, "normal", False),
+    (3, 0.28, "low",    True),   # THE DIP
+    (2, 0.55, "normal", False),
+    (1, 0.67, "good",   False),
+]
+
+# Representative feature sets per profile
+FEATURE_PROFILES = {
+    "normal": {
+        "energy": 0.038,
+        "pitch_mean": 198.0,
+        "pitch_std": 28.0,
+        "speech_rate": 9.5,
+        "pause_ratio": 0.38,
+        "duration_seconds": 240.0,
+    },
+    "good": {
+        "energy": 0.051,
+        "pitch_mean": 215.0,
+        "pitch_std": 35.0,
+        "speech_rate": 11.2,
+        "pause_ratio": 0.29,
+        "duration_seconds": 310.0,
+    },
+    "low": {
+        "energy": 0.018,
+        "pitch_mean": 155.0,
+        "pitch_std": 11.0,
+        "speech_rate": 4.1,
+        "pause_ratio": 0.71,
+        "duration_seconds": 185.0,
+    },
+}
+
+SAMPLE_TRANSCRIPTS = {
+    "normal": (
+        "Aria: Good morning Margaret! How are you feeling today?\n"
+        "User: Oh, pretty good I suppose. Had a nice cup of tea this morning.\n"
+        "Aria: That sounds lovely. Any plans for the day?\n"
+        "User: Not much, maybe watch some TV. Sarah called last night which was nice.\n"
+        "Aria: How wonderful that Sarah called. What did you two chat about?\n"
+        "User: Oh this and that. She's doing well at her job. I'm proud of her.\n"
+        "Aria: You should be! It's so nice to hear she's thriving.\n"
+        "User: Yes. Biscuit is being a bit clingy today too.\n"
+        "Aria: Cats always know when we need company. Take care Margaret, talk soon."
+    ),
+    "good": (
+        "Aria: Good morning Margaret! You sound bright today!\n"
+        "User: I do feel good! I slept wonderfully and made pancakes this morning.\n"
+        "Aria: Pancakes sound delicious. Any special occasion?\n"
+        "User: No, just felt like it! I called Sarah and she's visiting next weekend.\n"
+        "Aria: That's wonderful news — you must be so excited.\n"
+        "User: I am! I'm going to make her favourite lasagne.\n"
+        "Aria: She's a lucky daughter. Have a beautiful day Margaret."
+    ),
+    "low": (
+        "Aria: Good morning Margaret. How are you feeling today?\n"
+        "User: Not so great to be honest. I didn't sleep well.\n"
+        "Aria: I'm sorry to hear that. What kept you up?\n"
+        "User: Just... I don't know. Felt lonely I think. Everything feels a bit heavy.\n"
+        "Aria: I hear you Margaret. Those feelings are real and valid.\n"
+        "User: I just miss people. Biscuit is here but it's quiet.\n"
+        "Aria: You're not alone — I'm here, and I'll make sure someone checks in on you.\n"
+        "User: Thank you. That's kind.\n"
+        "Aria: Take good care of yourself today. Someone will be in touch soon."
+    ),
+}
+
+
+async def seed():
+    engine = create_async_engine(DATABASE_URL, echo=False)
+    Session = async_sessionmaker(bind=engine, expire_on_commit=False)
+
+    async with Session() as db:
+        # Find Margaret
+        from models.user import Call, User
+
+        result = await db.execute(select(User).where(User.name == "Margaret"))
+        margaret = result.scalars().first()
+        if not margaret:
+            print("ERROR: Margaret not found. Run scripts/seed_user.py first.")
+            return
+
+        # Check how many seeded calls already exist
+        existing = await db.execute(
+            text("SELECT COUNT(*) FROM calls WHERE user_id = :uid AND transcript IS NOT NULL"),
+            {"uid": str(margaret.id)},
+        )
+        count = existing.scalar()
+        if count and count >= 7:
+            print(f"Margaret already has {count} calls with transcripts. Skipping.")
+            print("To re-seed, delete existing calls first:")
+            print(f"  DELETE FROM calls WHERE user_id = '{margaret.id}';")
+            return
+
+        now = datetime.utcnow()
+        inserted = 0
+
+        for days_ago, mood_score, profile, flagged in CALL_PLAN:
+            call_time = now - timedelta(days=days_ago)
+            features = FEATURE_PROFILES[profile]
+            transcript = SAMPLE_TRANSCRIPTS[profile]
+
+            call = Call(
+                id=uuid.uuid4(),
+                user_id=margaret.id,
+                twilio_call_sid=f"CA_seed_{uuid.uuid4().hex[:16]}",
+                started_at=call_time,
+                ended_at=call_time + timedelta(minutes=int(features["duration_seconds"] // 60)),
+                transcript=transcript,
+                messages=[],
+                turn_count=transcript.count("Aria:"),
+                mood_score=mood_score,
+                mood_features=features,
+                mood_delta=round(mood_score - 0.5, 3),
+                flagged=flagged,
+                summary=f"{'Concerning call — Margaret sounded low' if flagged else 'Normal check-in call'}.",
+            )
+            db.add(call)
+            inserted += 1
+            flag_note = "  ← FLAGGED (SMS would fire)" if flagged else ""
+            print(f"  Day -{days_ago:1d}  mood={mood_score:.2f}  profile={profile}{flag_note}")
+
+        await db.commit()
+        print(f"\nInserted {inserted} seeded calls for Margaret ({margaret.id}).")
+        print("\nDemo tip:")
+        print("  Day -3 (score=0.28) is your dashboard demo moment.")
+        print("  Point to the dip and say: 'This triggered an SMS to Sarah automatically.'")
+        print(f"\nVerify: GET {os.getenv('BASE_URL', 'http://localhost:8001')}/mood/{margaret.id}")
+
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(seed())


### PR DESCRIPTION
## Summary
- Acoustic feature extraction (energy, pitch, speech rate, pause ratio) via librosa
- Mood scoring relative to personal 3-call baseline with SMS escalation on dip
- Call quality fixes: proper goodbye detection, no false escalations, recent-memory-based openings
- Seed script for demo mood history

## Changes
- `backend/services/mood.py` — librosa feature extraction + baseline scoring
- `backend/services/escalation.py` — centralised Twilio SMS
- `backend/routers/mood.py` — `GET /mood/{user_id}` for dashboard
- `backend/services/memory_service.py` — added `get_recent_memories` for opening greetings
- `backend/services/llm.py` — tighter escalation, goodbye detection, follow-up opening logic
- `backend/services/call_manager.py` — min-turn mood guard, user goodbye detection, prev opening context
- `scripts/seed_mood_history.py` — 7 fake calls with dip at day -3

## Test plan
- [ ] Trigger a call and verify mood score is written after 3+ turn call
- [ ] Verify Aria opens with a follow-up question about last call's topic
- [ ] Verify Aria does not repeat the same opening topic on consecutive calls
- [ ] Verify SMS fires only on genuine mood dip below baseline threshold
- [ ] Verify `GET /mood/{user_id}` returns scored calls in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)